### PR TITLE
typo in path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -89,7 +89,7 @@
 	    {
       "importedFileName": "12-licensing-reference",
       "pages": [],
-      "path": "sstock-api-docs/docs/api/12-licensing-reference.md",
+      "path": "stock-api-docs/docs/api/12-licensing-reference.md",
       "title": "Licensing reference"
     },
 	    {


### PR DESCRIPTION
there seems to be a typo in a path

# Pull request

## Issue# fixed
no issue

## Summary of Changes
- Fixed typo in Licensing reference path

## What kind of change does this PR introduce? 
- [ ] Technical content bug (_Example: HTTP request/response is wrong or incomplete_)
- [ ] Language bug (_Example: spelling/grammar mistake_)
- [ ] Enhancement (_Example: Clarifying or adding missing documentation, or adding language-specific example_)
- [X] Other: Typo in Manifest
- [ ] 



